### PR TITLE
Update JSON output helper

### DIFF
--- a/cmd/tls-scrape/main.go
+++ b/cmd/tls-scrape/main.go
@@ -22,13 +22,13 @@ func init() {
 	bindEnvWithFallback("fqdn")
 	bindEnvWithFallback("filepath")
 	bindEnvWithFallback("header")
-	bindEnvWithFallback("outfile")
+	bindEnvWithFallback("outdir")
 	bindEnvWithFallback("concurrency")
 
 	pflag.String("fqdn", "", "Fully Qualified Domain Name")
 	pflag.String("filepath", "", "Path to the websites CSV file")
 	pflag.String("header", "url", "Column header to look for in the CSV")
-	pflag.String("outfile", "", "Output path for JSON file")
+	pflag.String("outdir", "", "Output path for JSON file")
 	pflag.Int("concurrency", 10, "Maximum number of concurrent TLS connections")
 	pflag.Parse()
 	err := viper.BindPFlags(pflag.CommandLine)
@@ -42,7 +42,7 @@ func main() {
 	fqdn := viper.GetString("fqdn")
 	filepath := viper.GetString("filepath")
 	csvHeader := viper.GetString("header")
-	output := viper.GetString("outfile")
+	output := viper.GetString("outdir")
 	concurrency := viper.GetInt("concurrency")
 
 	if fqdn != "" && filepath != "" {
@@ -76,9 +76,11 @@ func main() {
 	}
 
 	if output != "" {
-		err = helper.WriteJSON(output, details)
-		if err != nil {
-			log.Fatal("Error writing JSON:", err)
+		for _, detail := range details {
+			err = helper.WriteJSON(output, detail)
+			if err != nil {
+				log.Fatal("Error writing JSON:", err)
+			}
 		}
 	}
 	err = helper.WriteLog(details)

--- a/internal/helper/io.go
+++ b/internal/helper/io.go
@@ -52,11 +52,12 @@ func ReadCSV(filename string, csvheader string) ([]string, error) {
 	return websites, nil
 }
 
-func WriteJSON(filename string, details []*scraper.CertDetails) error {
+func WriteJSON(directory string, details *scraper.CertDetails) error {
 	data, err := json.MarshalIndent(details, "", "  ")
 	if err != nil {
 		return err
 	}
+	filename := fmt.Sprintf("%s/%s.json", directory, details.Domain)
 	err = os.WriteFile(filename, data, 0644)
 	if err != nil {
 		return err


### PR DESCRIPTION
Use multi-file for JSON cmd output. Allows for easier consumption into a sidecar for example and helps aleviate use of nobody in container usage.

