### PR TITLE
Add new line to JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ You can configure the TLS Scrape tool using flags or environment variables:
 - **header**: The column header in the CSV to look for. Default is url.
 - **outfile**: Output path if you wish to save the results as a JSON file.
 - **concurrency**: Maximum number of concurrent TLS connections. Default is 10.
+- **prettyjson**: Pretty print the JSON output. Default is false.
 
 > [!NOTE]  
 > Only provide either fqdn or (filepath and header). Both can't be provided together.

--- a/internal/helper/io.go
+++ b/internal/helper/io.go
@@ -65,7 +65,8 @@ func WriteJSON(directory string, details *scraper.CertDetails, prettyPrint bool)
 	if err != nil {
 		return err
 	}
-
+	// Add a newline to the end of the file so that commands like tail can read it.
+	data = append(data, '\n')
 	filename := fmt.Sprintf("%s/%s.json", directory, details.Domain)
 	err = os.WriteFile(filename, data, 0644)
 	if err != nil {


### PR DESCRIPTION
Fix issue with tools like tail reading the JSON output by adding newline character '\n'