### PR TITLE
Update Go version in CI workflow to 1.24

### DIFF
--- a/.github/workflows/gotest.yaml
+++ b/.github/workflows/gotest.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.24'
 
       - name: Build
         run: go build -v ./cmd/...


### PR DESCRIPTION
Upgraded the Go version in the GitHub Actions workflow from 1.20 to 1.24. This ensures compatibility with the latest language features, optimizations, and security updates.